### PR TITLE
fix: mount tmp to container for running submitted code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM python:3.11-alpine
 WORKDIR /app
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN python -m venv venv && \
+    . venv/bin/activate && \
+    pip install --no-cache-dir -r requirements.txt
 
 COPY app/ .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - .env
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - /tmp:/tmp
     depends_on:
       - db
 


### PR DESCRIPTION
Fixes #19 

- Mount tmp in `docker-compose.yml`
- Run server in venv because live laugh love (I guess it's good practice and it keeps things isolated)