### PR TITLE
feat: add stdout for sample tests

### DIFF
--- a/app/services/execution/docker.py
+++ b/app/services/execution/docker.py
@@ -75,13 +75,15 @@ class DockerRunner:
         raise ValueError(f"Unsupported language: {lang}")
 
     def run_container(
-        self, lang: str, file_path: str, difficulty: str
+        self, lang: str, file_path: str, difficulty: str, line_offset: int
     ) -> ExecutionResult:
         """
         Run the code in a Docker container.
 
+        :param lang: The language of the code.
         :param file_path: The path to the file to run.
         :param difficulty: The difficulty of the problem.
+        :param line_offset: The line offset for error logs.
         :return: The result of the execution.
         """
         # Get the memory and time limits for the difficulty level.
@@ -131,12 +133,14 @@ class DockerRunner:
                     return ExecutionResult(
                         success=False,
                         message="Runtime Error Detected\n" + self.last_logs.strip(),
+                        line_offset=line_offset,
                     )
 
                 if self.last_stderr.strip():
                     return ExecutionResult(
                         success=False,
                         message="Runtime Error Detected\n" + self.last_stderr.strip(),
+                        line_offset=line_offset,
                     )
 
                 base_name = os.path.basename(file_path).split(".")[0]
@@ -150,6 +154,7 @@ class DockerRunner:
                         success=True,
                         test_results=execution_data["hidden_results"]["test_results"],
                         sample_results=execution_data["sample_results"]["test_results"],
+                        line_offset=line_offset,
                     )
                 else:
                     return ExecutionResult(

--- a/app/services/execution/service.py
+++ b/app/services/execution/service.py
@@ -64,7 +64,7 @@ class CodeExecutionService:
 
             # Create a temporary file to store the test runner file.
             with tempfile.NamedTemporaryFile(
-                mode="w", suffix=gen.get_file_extension(lang), delete=False
+                mode="w", suffix=gen.get_file_extension(), delete=False
             ) as f:
                 # Test data are pairs of test cases and its expected results.
                 test_data = [
@@ -83,7 +83,9 @@ class CodeExecutionService:
                 f.write(file_content)
                 file_path = f.name
             try:
-                result = self.docker.run_container(lang, file_path, difficulty)
+                result = self.docker.run_container(
+                    lang, file_path, difficulty, gen.get_line_offset()
+                )
 
                 # If all tests passed, get runtime analysis
                 if result.all_cleared() and not settings.TESTING:

--- a/app/services/execution/test_generator.py
+++ b/app/services/execution/test_generator.py
@@ -71,7 +71,7 @@ class PythonTestGenerator(TestGenerator):
         return ".py"
 
     def get_line_offset(self) -> int:
-        return 7
+        return 6
 
 
 class JavaTestGenerator(TestGenerator):
@@ -129,7 +129,7 @@ class JavaTestGenerator(TestGenerator):
         return ".java"
 
     def get_line_offset(self) -> int:
-        return 9
+        return 8
 
 
 class CppTestGenerator(TestGenerator):
@@ -208,4 +208,4 @@ class CppTestGenerator(TestGenerator):
         return ".cpp"
 
     def get_line_offset(self) -> int:
-        return 15
+        return 14

--- a/app/services/execution/test_generator.py
+++ b/app/services/execution/test_generator.py
@@ -30,12 +30,12 @@ class TestGenerator(ABC):
         """
 
     @abstractmethod
-    def get_file_extension(self, lang: str) -> str:
-        """
-        Get the file extension for the given language.
+    def get_file_extension(self) -> str:
+        """Get the file extension for the given language."""
 
-        :param lang: The language.
-        """
+    @abstractmethod
+    def get_line_offset(self) -> int:
+        """Get the line offset for the given language."""
 
     def process_quotes(self, json_str: str) -> str:
         """
@@ -67,8 +67,11 @@ class PythonTestGenerator(TestGenerator):
             sample_data=json.dumps(sample_data),
         )
 
-    def get_file_extension(self, lang: str) -> str:
+    def get_file_extension(self) -> str:
         return ".py"
+
+    def get_line_offset(self) -> int:
+        return 7
 
 
 class JavaTestGenerator(TestGenerator):
@@ -102,9 +105,6 @@ class JavaTestGenerator(TestGenerator):
             sample_data=sample_data,
         )
 
-    def get_file_extension(self, lang: str) -> str:
-        return ".java"
-
     def data_chunks(self, data: str) -> str:
         """
         Converts the data to a string of concatenated JSON strings.
@@ -124,6 +124,12 @@ class JavaTestGenerator(TestGenerator):
             cur += MAX_LENGTH
         chunks = "".join(['.append("' + s + '")' for s in json_strings])
         return f"new StringBuilder(){chunks}.toString()"
+
+    def get_file_extension(self) -> str:
+        return ".java"
+
+    def get_line_offset(self) -> int:
+        return 9
 
 
 class CppTestGenerator(TestGenerator):
@@ -198,5 +204,8 @@ class CppTestGenerator(TestGenerator):
             processed_data.append(data)
         return processed_data
 
-    def get_file_extension(self, lang: str) -> str:
+    def get_file_extension(self) -> str:
         return ".cpp"
+
+    def get_line_offset(self) -> int:
+        return 15

--- a/app/services/execution/types.py
+++ b/app/services/execution/types.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, Any, Optional
 
+
 class TestResult:
     def __init__(
         self,
@@ -16,18 +17,21 @@ class TestResult:
         self.logs = logs
         self.error = error
         self.input = input
-        
+
     def to_dict(self, is_sample: bool = True):
-        result = {{
-            "expected": self.expected,
-            "output": self.output,
-            "passed": self.passed,
-            "error": self.error,
-        }}
+        result = {
+            {
+                "expected": self.expected,
+                "output": self.output,
+                "passed": self.passed,
+                "error": self.error,
+            }
+        }
         if is_sample:
             result["logs"] = self.logs
             result["input"] = self.input
         return result
+
 
 class ExecutionResult:
     """

--- a/app/services/execution/types.py
+++ b/app/services/execution/types.py
@@ -1,5 +1,33 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Any, Optional
 
+class TestResult:
+    def __init__(
+        self,
+        expected: str,
+        passed: bool,
+        output: Any = None,
+        logs: str = None,
+        error: str = None,
+        input: str = None,
+    ):
+        self.expected = expected
+        self.output = str(output) if output is not None else None
+        self.passed = passed
+        self.logs = logs
+        self.error = error
+        self.input = input
+        
+    def to_dict(self, is_sample: bool = True):
+        result = {{
+            "expected": self.expected,
+            "output": self.output,
+            "passed": self.passed,
+            "error": self.error,
+        }}
+        if is_sample:
+            result["logs"] = self.logs
+            result["input"] = self.input
+        return result
 
 class ExecutionResult:
     """
@@ -10,8 +38,8 @@ class ExecutionResult:
         self,
         success: bool,
         message: Optional[str] = None,
-        test_results: Optional[List[Dict]] = None,
-        sample_results: Optional[List[Dict]] = None,
+        test_results: Optional[List[TestResult]] = None,
+        sample_results: Optional[List[TestResult]] = None,
         summary: Optional[Dict] = None,
         runtime_analysis: Optional[str] = None,
     ):

--- a/app/services/execution/types.py
+++ b/app/services/execution/types.py
@@ -42,6 +42,7 @@ class ExecutionResult:
         self,
         success: bool,
         message: Optional[str] = None,
+        line_offset: Optional[int] = None,  # for error logs from templates
         test_results: Optional[List[TestResult]] = None,
         sample_results: Optional[List[TestResult]] = None,
         summary: Optional[Dict] = None,
@@ -49,6 +50,7 @@ class ExecutionResult:
     ):
         self.success = success
         self.message = message
+        self.line_offset = line_offset
         self.test_results = test_results
         self.sample_results = sample_results
         self.summary = summary
@@ -71,6 +73,7 @@ class ExecutionResult:
         return {
             "success": self.success,
             "message": self.message,
+            "line_offset": self.line_offset,
             "test_results": self.test_results,
             "sample_results": self.sample_results,
             "summary": self.summary

--- a/app/tests/unit/code_execution_test.py
+++ b/app/tests/unit/code_execution_test.py
@@ -11,7 +11,6 @@ from services.execution.service import CodeExecutionService
 # fmt: on
 
 
-@pytest.mark.skip()
 class TestPython:
     @pytest.fixture
     def executor(self):
@@ -273,7 +272,6 @@ class Solution:
         )
 
 
-@pytest.mark.skip()
 class TestJava:
     @pytest.fixture
     def executor(self):
@@ -645,9 +643,7 @@ public:
             compare_func="return result == expected;",
             lang="cpp",
         )
-        import pdb
 
-        pdb.set_trace()
         assert result.success
         assert len(result.test_results) == 3
         assert all(test["passed"] for test in result.test_results)

--- a/app/tests/unit/code_execution_test.py
+++ b/app/tests/unit/code_execution_test.py
@@ -10,6 +10,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../.
 from services.execution.service import CodeExecutionService
 # fmt: on
 
+
 @pytest.mark.skip()
 class TestPython:
     @pytest.fixture
@@ -271,8 +272,8 @@ class Solution:
             > executor._execution_semaphores["hard"]._value
         )
 
-@pytest.mark.skip()
 
+@pytest.mark.skip()
 class TestJava:
     @pytest.fixture
     def executor(self):
@@ -644,7 +645,9 @@ public:
             compare_func="return result == expected;",
             lang="cpp",
         )
-        import pdb; pdb.set_trace()
+        import pdb
+
+        pdb.set_trace()
         assert result.success
         assert len(result.test_results) == 3
         assert all(test["passed"] for test in result.test_results)

--- a/app/tests/unit/code_execution_test.py
+++ b/app/tests/unit/code_execution_test.py
@@ -10,7 +10,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../.
 from services.execution.service import CodeExecutionService
 # fmt: on
 
-
+@pytest.mark.skip()
 class TestPython:
     @pytest.fixture
     def executor(self):
@@ -31,6 +31,15 @@ class Solution:
                 return [seen[complement], i]
             seen[num] = i
         return []
+"""
+
+    @pytest.fixture
+    def log_solution(self):
+        return """
+class Solution:
+    def add(self, a: int, b: int) -> int:
+        print("Hello, World!")
+        return a + b
 """
 
     @pytest.fixture
@@ -110,6 +119,22 @@ class Solution:
         assert len(result.test_results) == 2
         assert not any(test["passed"] for test in result.test_results)
         assert all(test["error"] is None for test in result.test_results)
+
+    @pytest.mark.asyncio
+    async def test_if_show_logs(self, executor, log_solution):
+        result = await executor.execute_code(
+            code=log_solution,
+            method_name="add",
+            test_cases=["--arg1=1 --arg2=2"],
+            expected_results=["3"],
+            sample_test_cases=["--arg1=1 --arg2=2"],
+            sample_expected_results=["3"],
+            difficulty="easy",
+            compare_func="return result == int(expected)",
+        )
+
+        assert result.success
+        assert any("Hello, World!" in test["logs"] for test in result.sample_results)
 
     @pytest.mark.asyncio
     async def test_syntax_error(self, executor, invalid_syntax_solution):
@@ -246,6 +271,7 @@ class Solution:
             > executor._execution_semaphores["hard"]._value
         )
 
+@pytest.mark.skip()
 
 class TestJava:
     @pytest.fixture
@@ -270,6 +296,17 @@ class Solution {
             seen.put(nums[i], i);
         }
         return new int[]{};
+    }
+}
+"""
+
+    @pytest.fixture
+    def log_solution(self):
+        return """
+class Solution {
+    public int add(int a, int b) {
+        System.out.println("Hello, World!");
+        return a + b;
     }
 }
 """
@@ -357,6 +394,23 @@ class Solution {
         assert len(result.test_results) == 2
         assert not any(test["passed"] for test in result.test_results)
         assert all("error" not in test for test in result.test_results)
+
+    @pytest.mark.asyncio
+    async def test_if_show_logs(self, executor, log_solution):
+        result = await executor.execute_code(
+            code=log_solution,
+            method_name="add",
+            test_cases=["--arg1=1 --arg2=2"],
+            expected_results=["3"],
+            sample_test_cases=["--arg1=1 --arg2=2"],
+            sample_expected_results=["3"],
+            difficulty="easy",
+            compare_func="return ((Integer)result).intValue() == ((Integer)expected).intValue();",
+            lang="java",
+        )
+
+        assert result.success
+        assert any("Hello, World!" in test["logs"] for test in result.sample_results)
 
     @pytest.mark.asyncio
     async def test_syntax_error(self, executor, invalid_syntax_solution):
@@ -511,6 +565,18 @@ public:
 """
 
     @pytest.fixture
+    def log_solution(self):
+        return r"""
+class Solution {
+public:
+    int add(int a, int b) {
+        cout << "Hello, World!";
+        return a + b;
+    }
+};
+"""
+
+    @pytest.fixture
     def invalid_syntax_solution(self):
         # Missing a semicolon after the return statement.
         return r"""
@@ -578,6 +644,7 @@ public:
             compare_func="return result == expected;",
             lang="cpp",
         )
+        import pdb; pdb.set_trace()
         assert result.success
         assert len(result.test_results) == 3
         assert all(test["passed"] for test in result.test_results)
@@ -598,6 +665,23 @@ public:
         assert result.success
         assert len(result.test_results) == 2
         assert not any(test["passed"] for test in result.test_results)
+
+    @pytest.mark.asyncio
+    async def test_if_show_logs(self, executor, log_solution):
+        result = await executor.execute_code(
+            code=log_solution,
+            method_name="add",
+            test_cases=["--arg1=1 --arg2=2"],
+            expected_results=["3"],
+            sample_test_cases=["--arg1=1 --arg2=2"],
+            sample_expected_results=["3"],
+            difficulty="easy",
+            compare_func="return result == expected;",
+            lang="cpp",
+        )
+
+        assert result.success
+        assert any("Hello, World!" in test["logs"] for test in result.sample_results)
 
     @pytest.mark.asyncio
     async def test_syntax_error(self, executor, invalid_syntax_solution):


### PR DESCRIPTION
Fixes #42 
Closes #22  (Fixed on frontend)

Code with stdout commands like `print` or `cout` will have sample test output following this format
```diff
{
   "passed": false,
   "output": "\"\"",
   "expected": "'100'",
+  "logs": "oshi no ko is peak",
   "input": "--arg1=\"11\" --arg2=\"1\""
}
```